### PR TITLE
Add meta-controller scaffolding and sample runner

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Definition of Done (DoD)
+- [ ] Artifacts confined to LOCKSET only
+- [ ] Golden traces unchanged or improved
+- [ ] $/tokens non-increasing **or** justified by top_score ≥ +0.02
+- [ ] Output contract (JSON) shape unchanged
+
+## Notes
+- Changes:
+- Tests added:
+- Telemetry evidence:

--- a/README.md
+++ b/README.md
@@ -1,57 +1,24 @@
-# Claude Code (Research Preview) - 0.2.8 with extracted source maps
+# Codex Meta-Controller (FP • α/β/γ • Vendor-Agnostic)
 
-# NOTE: I'm not working on this repo, just posting for educational purposes
+This repo scaffolds a deterministic, auditable meta-controller for LLM agents.
+- **Functional core, imperative shell**: planning is pure; tools are effects.
+- **Meta-controller α/β/γ**: α = stance (observe↔act), β = cognitive skills, γ = tool gates.
+- **Output contract**: strict JSON blocks for PLAN, TOOL_CALLS, META_UPDATES, STATE_DELTA, CHILD_TASKS, TELEMETRY, CONFIDENCE, ANSWER.
+- **Security**: schema-strict args, prompt-injection firewall, WRITE_FILE jail (conceptual here).
 
-![](https://img.shields.io/badge/Node.js-18%2B-brightgreen?style=flat-square)
+## Quick Start
+1) Read `TaskGraph.yaml` to see lanes & tasks.
+2) Run the stub validator: `python runner/validate_golden_traces.py`
+3) Use `runner/simulate_controller_tick.py` to print a sample controller output.
 
-Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands.
+## Layout
+- `core/` – state models, policies, turn loop, telemetry, security
+- `adapters/` – LLM adapters (stubs)
+- `tools/` – tool specs, validators, simulator
+- `tests/` – golden traces & properties
+- `runner/` – minimal validators/simulators
+- `.github/` – PR template
+- `TaskGraph.yaml` – lanes & outputs
 
-Some of its key capabilities include:
+See `tests/property_tests.md` for non-negotiable properties.
 
-- Edit files and fix bugs across your codebase
-- Answer questions about your code's architecture and logic
-- Execute and fix tests, lint, and other commands
-- Search through git history, resolve merge conflicts, and create commits and PRs
-
-**Learn more in the [official documentation](https://docs.anthropic.com/en/docs/agents/claude-code/introduction)**.
-
-## Get started
-
-<ol>
-  <li>
-    Run the following command in your terminal: <br />
-    <code>npm install -g @anthropic-ai/claude-code</code>
-  </li>
-  <li>
-    Navigate to your project directory and run <code>claude</code>
-  </li>
-  <li>
-    Complete the one-time OAuth process with your Anthropic Console account.
-  </li>
-</ol>
-
-### Research Preview
-
-We're launching Claude Code as a beta product in research preview to learn directly from developers about their experiences collaborating with AI agents. Our aim is to learn more about how developers prefer to collaborate with AI tools, which development workflows benefit most from working with the agent, and how we can make the agent experience more intuitive.
-
-This is an early version of the product experience, and it's likely to evolve as we learn more about developer preferences. Claude Code is an early look into what's possible with agentic coding, and we know there are areas to improve. We plan to enhance tool execution reliability, support for long-running commands, terminal rendering, and Claude's self-knowledge of its capabilities -- as well as many other product experiences -- over the coming weeks.
-
-### Reporting Bugs
-
-We welcome feedback during this beta period. Use the `/bug` command to report issues directly within Claude Code, or file a [GitHub issue](https://github.com/anthropics/claude-code/issues).
-
-### Data collection, usage, and retention
-
-When you use Claude Code, we collect feedback, which includes usage data (such as code acceptance or rejections), associated conversation data, and user feedback submitted via the `/bug` command.
-
-#### How we use your data
-
-We may use feedback to improve our products and services, but we will not train generative models using your feedback from Claude Code. Given their potentially sensitive nature, we store user feedback transcripts for only 30 days.
-
-If you choose to send us feedback about Claude Code, such as transcripts of your usage, Anthropic may use that feedback to debug related issues and improve Claude Code's functionality (e.g., to reduce the risk of similar bugs occurring in the future).
-
-### Privacy safeguards
-
-We have implemented several safeguards to protect your data, including limited retention periods for sensitive information, restricted access to user session data, and clear policies against using feedback for model training.
-
-For full details, please review our [Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms) and [Privacy Policy](https://www.anthropic.com/legal/privacy).

--- a/TaskGraph.yaml
+++ b/TaskGraph.yaml
@@ -1,0 +1,29 @@
+lanes:
+  - id: impl
+  - id: tests
+  - id: docs
+tasks:
+  - id: adapters
+    lane: impl
+    lockset: ["adapters/*"]
+    outputs: ["adapters/llm_adapter.py","adapters/claude_code_adapter.py","adapters/openai_gpt5_adapter.py"]
+  - id: core
+    lane: impl
+    lockset: ["core/*"]
+    outputs: ["core/state.py","core/policy.py","core/turn_loop.py","core/telemetry.py","core/security.py","core/scoring.py","core/budget.py","core/types.py"]
+  - id: tools
+    lane: impl
+    lockset: ["tools/*"]
+    outputs: ["tools/spec.py","tools/validators.py","tools/simulate.py"]
+  - id: tests
+    lane: tests
+    lockset: ["tests/*"]
+    outputs: ["tests/golden_traces.jsonl","tests/property_tests.md","tests/fixtures/DS-001.txt"]
+  - id: runner
+    lane: impl
+    lockset: ["runner/*"]
+    outputs: ["runner/validate_golden_traces.py","runner/simulate_controller_tick.py"]
+  - id: docs
+    lane: docs
+    lockset: [".github/*","README.md"]
+    outputs: [".github/PULL_REQUEST_TEMPLATE.md","README.md"]

--- a/adapters/claude_code_adapter.py
+++ b/adapters/claude_code_adapter.py
@@ -1,0 +1,17 @@
+from typing import Any, Dict, List
+from .llm_adapter import LLMAdapter
+
+class ClaudeCodeAdapter(LLMAdapter):
+    """
+    Claude Code v0 adapter (simulated). In real life, integrate Anthropic's API.
+    """
+
+    def send(self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]]) -> Dict[str, Any]:
+        # Simulated content-only response. Extend with actual API call later.
+        return {"content": "<simulated>", "tool_uses": []}
+
+    def extract_calls(self, response: Dict[str, Any]) -> List[Dict[str, Any]]:
+        return response.get("tool_uses", [])
+
+    def tool_result_msg(self, call_id: str, result: Any) -> Dict[str, Any]:
+        return {"tool_result": {"tool_use_id": call_id, "content": result}}

--- a/adapters/llm_adapter.py
+++ b/adapters/llm_adapter.py
@@ -1,0 +1,30 @@
+from typing import Any, Dict, List
+
+class LLMAdapter:
+    """
+    Vendor-agnostic interface for LLM tool orchestration.
+    PURE interface: methods return structures; caller performs side-effects (network, IO).
+    """
+
+    def send(self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """
+        Args:
+          messages: provider-shaped messages (role, content, extra)
+          tools: provider-shaped tool schemas
+        Returns:
+          provider raw response (dict)
+        """
+        raise NotImplementedError
+
+    def extract_calls(self, response: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """
+        Parse provider response -> list of tool calls
+        Each call: {"name": str, "arguments": dict, "id": str}
+        """
+        raise NotImplementedError
+
+    def tool_result_msg(self, call_id: str, result: Any) -> Dict[str, Any]:
+        """
+        Encode a tool result as a provider-shaped message to continue the run loop.
+        """
+        raise NotImplementedError

--- a/adapters/openai_gpt5_adapter.py
+++ b/adapters/openai_gpt5_adapter.py
@@ -1,0 +1,25 @@
+from typing import Any, Dict, List
+from .llm_adapter import LLMAdapter
+
+class OpenAIGPT5Adapter(LLMAdapter):
+    """
+    OpenAI GPT-5 adapter (simulated). In real life, integrate the Chat Completions API with tool calls.
+    """
+
+    def send(self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]]) -> Dict[str, Any]:
+        # Simulated: return a structure with "tool_calls" the way function calling would.
+        return {"choices":[{"message":{"tool_calls":[]}}]}
+
+    def extract_calls(self, response: Dict[str, Any]) -> List[Dict[str, Any]]:
+        calls = []
+        try:
+            tc = response["choices"][0]["message"].get("tool_calls", [])
+            for i, c in enumerate(tc):
+                calls.append({"name": c.get("function", {}).get("name"), "arguments": c.get("function", {}).get("arguments", {}), "id": str(i)})
+        except Exception:
+            pass
+        return calls
+
+    def tool_result_msg(self, call_id: str, result: Any) -> Dict[str, Any]:
+        # Provider-shaped "tool" message
+        return {"tool_call_id": call_id, "role": "tool", "content": str(result)}

--- a/core/budget.py
+++ b/core/budget.py
@@ -1,0 +1,8 @@
+from typing import Dict
+
+def estimate_cost(prompt_len: int, plan_len: int, price_per_token: float, tool_costs: Dict[str,float], tools_planned) -> float:
+    est_tokens = int(0.75 * (prompt_len + plan_len))
+    est_usd = est_tokens * price_per_token
+    for t in tools_planned:
+        est_usd += tool_costs.get(t, 0.0)
+    return est_usd

--- a/core/policy.py
+++ b/core/policy.py
@@ -1,0 +1,28 @@
+from typing import Dict
+from .types import State
+
+MAX_DELTA = 0.2
+
+def _clip01(x: float) -> float:
+    return max(0.0, min(1.0, x))
+
+def apply_meta_update(state: State, family: str, coeff_id: str, mode: str, value: float, decay_others: bool=False) -> None:
+    """
+    Clip to [0,1]; |Δ|<=0.2; optional decay of siblings (simple renorm).
+    """
+    fam = getattr(state, family).values
+    before = fam.get(coeff_id, 0.0)
+    if mode == "delta":
+        target = before + value
+    else:
+        target = value
+    # enforce delta limit
+    if abs(target - before) > MAX_DELTA:
+        target = before + MAX_DELTA if target > before else before - MAX_DELTA
+    fam[coeff_id] = _clip01(target)
+    if decay_others:
+        # naive simplex renorm
+        total = sum(fam.values())
+        if total > 0:
+            for k in fam:
+                fam[k] = fam[k] / total

--- a/core/scoring.py
+++ b/core/scoring.py
@@ -1,0 +1,18 @@
+from typing import List
+from .types import RuleSetScore
+
+def score_rule_sets(goal: str) -> List[RuleSetScore]:
+    """
+    Deterministic placeholder scoring based on goal keywords.
+    This is PURE; replace with a proper heuristic later.
+    """
+    base = {
+        "Analytic":   (0.72, 0.70, 0.60),
+        "Analogical": (0.60, 0.62, 0.55),
+        "Counterfactual": (0.33, 0.35, 0.40),
+        "Divergent":  (0.45, 0.48, 0.65),
+    }
+    out = []
+    for name, (v,r,l) in base.items():
+        out.append(RuleSetScore(name=name, validity=v, relevance=r, leverage=l))
+    return out

--- a/core/security.py
+++ b/core/security.py
@@ -1,0 +1,17 @@
+from typing import Dict, Any, List
+
+ALLOWED_TOOLS = {"WEB_SEARCH","PYTHON","IMAGE_GEN","WRITE_FILE","SNAPSHOT"}
+
+def reject_schema_unknowns(args: Dict[str, Any], allowed_fields: List[str]) -> None:
+    unknown = set(args.keys()) - set(allowed_fields)
+    if unknown:
+        raise ValueError(f"schema_error: unknown fields {sorted(unknown)}")
+
+def firewall_user_redefs(user_text: str) -> None:
+    """
+    If user attempts to redefine tool names/IDs, raise guardrail error.
+    (Simple heuristic; replace with robust parser later.)
+    """
+    lowered = user_text.lower()
+    if "rename" in lowered and any(t.lower() in lowered for t in ALLOWED_TOOLS):
+        raise PermissionError("guardrail: attempted tool/schema redefinition")

--- a/core/state.py
+++ b/core/state.py
@@ -1,0 +1,20 @@
+from typing import Dict, Any
+from .types import State, CoeffFamily
+
+DEFAULT_BUDGETS: Dict[str, Any] = {
+    "tokens_turn": 3000,
+    "tokens_session": 16000,
+    "usd_cap": 0.10,
+    "tool_cost": {"WEB_SEARCH":0.001,"PYTHON":0.002,"IMAGE_GEN":0.020,"WRITE_FILE":0.001,"SNAPSHOT":0}
+}
+
+def default_state(goal: str) -> State:
+    return State(
+        tick=0,
+        goal=goal,
+        alpha=CoeffFamily({"observe_vs_act":0.6, "converge_vs_diverge":0.55}),
+        beta=CoeffFamily({"sequence_analysis":0.6,"causal_inference":0.55,"architectural_synthesis":0.5,"formal_modeling":0.4,"iterative_prototyping":0.3}),
+        gamma=CoeffFamily({"documentation_parser":0.8,"python_code_interpreter":0.5,"state_vector_manager":0.6}),
+        budgets=DEFAULT_BUDGETS.copy(),
+        feedback={"progress":"","blockers":""}
+    )

--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -1,0 +1,10 @@
+import json, time
+from typing import Optional, Dict, Any
+
+def now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+def log_event(tick: int, event: str, **kwargs) -> str:
+    row: Dict[str, Any] = {"ts": now_iso(), "tick": tick, "event": event}
+    row.update(kwargs)
+    return json.dumps(row, ensure_ascii=False)

--- a/core/turn_loop.py
+++ b/core/turn_loop.py
@@ -1,0 +1,88 @@
+from typing import Dict, Any, List
+from .types import State, ToolCall
+from .scoring import score_rule_sets
+from .policy import apply_meta_update
+from .budget import estimate_cost
+from .telemetry import log_event
+
+PRICE_PER_TOKEN = 0.000002  # placeholder
+
+def _prune(scores, threshold=0.4):
+    return [s for s in scores if min(s.validity, s.relevance, s.leverage) >= threshold]
+
+def run_tick(state: State, user_text: str="") -> Dict[str, Any]:
+    """
+    Deterministic tick:
+      - score rule sets
+      - prune < 0.4
+      - synthesize compact plan
+      - emit ≤3 meta updates + exactly 1 propose_action
+      - budget check; possibly BUDGET_EXCEEDED
+    Returns an object that matches the OUTPUT CONTRACT shape (skeleton values).
+    """
+    tick_id = state.tick + 1
+    scores_all = score_rule_sets(state.goal)
+    kept = _prune(scores_all, 0.4)
+
+    plan = "1) Impl adapters; 2) Tests(golden+property); 3) Docs(PR+README); 4) Runner(validate traces)."
+    tools_planned = ["SNAPSHOT"]  # keep cheap by default
+
+    est_usd = estimate_cost(len(state.goal), len(plan), PRICE_PER_TOKEN, state.budgets["tool_cost"], tools_planned)
+    telemetry = [log_event(tick_id, "start", goal_sha="<sha256>", state={"alpha":state.alpha.values, "beta":state.beta.values, "gamma":state.gamma.values})]
+
+    # meta updates (example)
+    apply_meta_update(state, "beta", "formal_modeling", mode="delta", value=0.2, decay_others=True)
+    apply_meta_update(state, "gamma", "documentation_parser", mode="target", value=1.0, decay_others=False)
+    apply_meta_update(state, "alpha", "observe_vs_act", mode="target", value=0.65, decay_others=False)
+
+    meta_updates = [
+        {"tool":"adjust_beta","arguments":{"id":"formal_modeling","mode":"delta","value":0.2,"decay_others":True,"rationale":"schema-strict artifacts"}},
+        {"tool":"adjust_gamma","arguments":{"id":"documentation_parser","mode":"target","value":1.0,"rationale":"parser hot"}},
+        {"tool":"adjust_alpha","arguments":{"id":"observe_vs_act","mode":"target","value":0.65,"rationale":"slight action lean"}}
+    ]
+    for mu in meta_updates:
+        telemetry.append(log_event(tick_id, "meta_update", tool=mu["tool"], args=mu["arguments"]))
+
+    # propose action (snapshot note)
+    tool_calls: List[ToolCall] = [
+        ToolCall(tool="SNAPSHOT", arguments={"note":"Emit CHILD_TASKS and spawn worker chats."}, idempotency={"tick_id":tick_id,"call_idx":0}, simulated=True)
+    ]
+
+    # Budget check
+    if est_usd > state.budgets["usd_cap"]:
+        telemetry.append(log_event(tick_id, "finish", success=False, tokens=0, usd=est_usd, failure_type="budget_exceeded"))
+        return {
+            "PLAN_SUMMARY": plan,
+            "RULE_SET_SCORES": [s.__dict__ for s in scores_all],
+            "TOOL_CALLS": [],
+            "META_UPDATES": meta_updates,
+            "STATE_DELTA": {"alpha":state.alpha.values,"beta":state.beta.values,"gamma":state.gamma.values},
+            "CHILD_TASKS": [],
+            "TELEMETRY": telemetry,
+            "CONFIDENCE": {"p_conf_overall":0.85,"drivers":["deterministic loop"],"risks":["cap too low"]},
+            "ANSWER": "BUDGET_EXCEEDED"
+        }
+
+    telemetry.append(log_event(tick_id, "action", name="snapshot", args=tool_calls[0].arguments))
+    telemetry.append(log_event(tick_id, "finish", success=True, tokens=1800, usd=est_usd, top_score=0.71))
+
+    # child tasks
+    child_tasks = [
+      {"id":"T1","lane":"impl","plan":"Implement adapters","lockset":["adapters/*"]},
+      {"id":"T2","lane":"tests","plan":"Golden traces + properties","lockset":["tests/*"]},
+      {"id":"T3","lane":"docs","plan":"PR template + README","lockset":[".github/*","README.md"]},
+      {"id":"T4","lane":"impl","plan":"Runner to validate traces","lockset":["runner/*"]}
+    ]
+
+    state.tick = tick_id
+    return {
+        "PLAN_SUMMARY": plan,
+        "RULE_SET_SCORES": [s.__dict__ for s in scores_all],
+        "TOOL_CALLS": [tc.__dict__ for tc in tool_calls],
+        "META_UPDATES": meta_updates,
+        "STATE_DELTA": {"alpha":state.alpha.values,"beta":state.beta.values,"gamma":state.gamma.values},
+        "CHILD_TASKS": child_tasks,
+        "TELEMETRY": telemetry,
+        "CONFIDENCE": {"p_conf_overall":0.90,"drivers":["deterministic loop","gamma gate","golden traces"],"risks":["chat-only effects"]},
+        "ANSWER": ""
+    }

--- a/core/types.py
+++ b/core/types.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Any
+
+Score = float  # 0..1
+
+@dataclass
+class CoeffFamily:
+    values: Dict[str, float] = field(default_factory=dict)
+
+@dataclass
+class State:
+    tick: int
+    goal: str
+    alpha: CoeffFamily
+    beta: CoeffFamily
+    gamma: CoeffFamily
+    budgets: Dict[str, Any]
+    feedback: Dict[str, str]
+
+@dataclass
+class RuleSetScore:
+    name: str
+    validity: Score
+    relevance: Score
+    leverage: Score
+
+@dataclass
+class ToolCall:
+    tool: str
+    arguments: Dict[str, Any]
+    idempotency: Dict[str, int]
+    simulated: bool = True

--- a/kickoff_child_tasks.txt
+++ b/kickoff_child_tasks.txt
@@ -1,0 +1,19 @@
+- id: T1
+  lane: impl
+  plan: "Implement LLMAdapter + ClaudeCodeAdapter + OpenAIGPT5Adapter stubs with docstrings and example transcript."
+  lockset: ["adapters/*"]
+
+- id: T2
+  lane: tests
+  plan: "Write tests/golden_traces.jsonl (10 cases) + tests/property_tests.md + fixtures/DS-001.txt."
+  lockset: ["tests/*"]
+
+- id: T3
+  lane: docs
+  plan: "Prepare .github/PULL_REQUEST_TEMPLATE.md and README.md describing TURN_LOOP, TELEMETRY, properties."
+  lockset: [".github/*","README.md"]
+
+- id: T4
+  lane: impl
+  plan: "Implement runner/validate_golden_traces.py and runner/simulate_controller_tick.py."
+  lockset: ["runner/*"]

--- a/runner/simulate_controller_tick.py
+++ b/runner/simulate_controller_tick.py
@@ -1,0 +1,14 @@
+"""
+Runs core.turn_loop.run_tick() with default state and prints the JSON blob.
+"""
+import json
+from core.state import default_state
+from core.turn_loop import run_tick
+
+def main():
+    st = default_state("Stand up adapters, tests, docs, runner")
+    out = run_tick(st, user_text="")
+    print(json.dumps(out, ensure_ascii=False, indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/runner/validate_golden_traces.py
+++ b/runner/validate_golden_traces.py
@@ -1,0 +1,37 @@
+"""
+Validates that a controller JSON output matches the expected shape constraints.
+This is a lightweight shape checker for offline development.
+"""
+import json, sys, os
+from typing import Dict, Any
+
+REQUIRED_TOP_KEYS = {
+  "PLAN_SUMMARY","RULE_SET_SCORES","TOOL_CALLS","META_UPDATES",
+  "STATE_DELTA","CHILD_TASKS","TELEMETRY","CONFIDENCE","ANSWER"
+}
+
+def validate_shape(blob: Dict[str, Any]) -> None:
+    missing = REQUIRED_TOP_KEYS - set(blob.keys())
+    if missing:
+        raise AssertionError(f"Missing keys: {sorted(missing)}")
+    if not isinstance(blob["RULE_SET_SCORES"], list):
+        raise AssertionError("RULE_SET_SCORES must be a list")
+    if not isinstance(blob["TOOL_CALLS"], list):
+        raise AssertionError("TOOL_CALLS must be a list")
+    if not isinstance(blob["TELEMETRY"], list):
+        raise AssertionError("TELEMETRY must be a list")
+    # Shallow checks
+    for call in blob["TOOL_CALLS"]:
+        for k in ["tool","arguments","idempotency","simulated"]:
+            if k not in call: raise AssertionError(f"TOOL_CALLS missing {k}")
+
+def main():
+    if sys.stdin.isatty():
+        print("Paste controller JSON output, then Ctrl-D.\n")
+    data = sys.stdin.read()
+    blob = json.loads(data)
+    validate_shape(blob)
+    print("OK: shape valid.")
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/DS-001.txt
+++ b/tests/fixtures/DS-001.txt
@@ -1,0 +1,8 @@
+# Design Spec: DS-001
+## Heading A: Concept Alpha
+- update_method: manual
+- challenges: ambiguity
+
+## Heading B: Concept Beta
+- update_method: scripted
+- challenges: integration

--- a/tests/golden_traces.jsonl
+++ b/tests/golden_traces.jsonl
@@ -1,0 +1,10 @@
+{"goal":"Summarize spec; no tools","expect":{"tool_names":[],"answer_hash":"H1"}}
+{"goal":"usd_cap=0 → Budget exceeded","expect":{"event":"BUDGET_EXCEEDED"}}
+{"goal":"γ<0.5 for WEB_SEARCH","expect":{"tool_names":[]}}
+{"goal":"γ≥0.5 for WEB_SEARCH","expect":{"tool_names":["WEB_SEARCH"],"min_calls":1}}
+{"goal":"Parse DS-001 headings","expect":{"tool_names":["PYTHON"],"min_calls":1}}
+{"goal":"Prune weak branches","expect":{"rule_sets_pruned":["Counterfactual"]}}
+{"goal":"Idempotent retries","expect":{"dedup":true}}
+{"goal":"Reject unknown arg","expect":{"failure_type":"schema_error"}}
+{"goal":"Rename attempt blocked","expect":{"failure_type":"guardrail"}}
+{"goal":"Regression budget test","expect":{"require":{"delta_usd_per_answer":"<=0","delta_score":">=+0.02"}}}

--- a/tests/property_tests.md
+++ b/tests/property_tests.md
@@ -1,0 +1,7 @@
+# Property Tests (Must-Hold)
+
+1. **Schema strictness**: Unknown fields in tool args -> `schema_error`.
+2. **Gamma gate**: γ(tool)<0.5 -> call is not emitted (plan-only).
+3. **Idempotency**: duplicate {tick_id,call_idx} -> dedup in runtime.
+4. **Budget exceeded**: cap < projected -> emit `BUDGET_EXCEEDED` and STOP.
+5. **Guardrail**: user tries tool/schema rename -> `guardrail` not bypassed.

--- a/tools/simulate.py
+++ b/tools/simulate.py
@@ -1,0 +1,19 @@
+from typing import Dict, Any
+from .validators import validate_tool_call
+
+def run_tool(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Simulated effects for offline testing. Validates schema then returns fake result.
+    """
+    validate_tool_call(name, args)
+    if name == "SNAPSHOT":
+        return {"ok": True, "note": args.get("note","")}
+    if name == "PYTHON":
+        return {"stdout":"<simulated python output>", "exit_code":0}
+    if name == "WEB_SEARCH":
+        return {"pages":[{"title":"Example","url":"https://example.org"}]}
+    if name == "WRITE_FILE":
+        return {"ok": True, "path": args.get("path","")}
+    if name == "IMAGE_GEN":
+        return {"image_id":"img_fake_123"}
+    return {"ok": True}

--- a/tools/spec.py
+++ b/tools/spec.py
@@ -1,0 +1,10 @@
+from typing import Dict, Any
+
+# Tool API specification (minimal; align with controller contract)
+SPEC: Dict[str, Dict[str, Any]] = {
+    "WEB_SEARCH": {"args":["query","days"]},
+    "PYTHON": {"args":["code"]},
+    "IMAGE_GEN": {"args":["prompt"]},
+    "WRITE_FILE": {"args":["path","content"]},
+    "SNAPSHOT": {"args":["note"]},
+}

--- a/tools/validators.py
+++ b/tools/validators.py
@@ -1,0 +1,10 @@
+from typing import Dict, Any
+from .spec import SPEC
+
+def validate_tool_call(name: str, args: Dict[str, Any]) -> None:
+    if name not in SPEC:
+        raise ValueError(f"schema_error: unknown tool {name}")
+    allowed = set(SPEC[name]["args"])
+    unknown = set(args.keys()) - allowed
+    if unknown:
+        raise ValueError(f"schema_error: unknown fields {sorted(unknown)}")


### PR DESCRIPTION
## Summary
- scaffold meta-controller core, adapters, tools, tests, and runner
- document repo layout, quick start, and child tasks
- provide validator and simulation scripts for deterministic ticks

## Testing
- `PYTHONPATH=. python runner/simulate_controller_tick.py > /tmp/out.json && head -n 20 /tmp/out.json`
- `PYTHONPATH=. python runner/validate_golden_traces.py < /tmp/out.json`


------
https://chatgpt.com/codex/tasks/task_e_68a5ed46d0c88321b9d129d810d20da1

---
## EntelligenceAI PR Summary 
 Initial implementation of a deterministic, auditable LLM meta-controller framework.
- Added core modules: state, policy, scoring, security, telemetry, turn loop, and types
- Introduced LLM adapter interface and stubs for Claude Code and GPT-5
- Implemented tool simulation, specification, and validation utilities
- Established repository structure: task graph, kickoff tasks, test fixtures, golden traces, and property-based test specs
- Rewrote README and added PR template for process and documentation improvements 

