### PR TITLE
Add CLAUDE instructions with workflow heuristics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE Instructions for claudecode
+
+This repository hosts the extracted source for the Claude Code CLI (research preview).
+The notes below encode heuristics from experienced Anthropic CLI users.
+
+## Workflow
+- **Explore → Plan → Code → Commit**
+  - Read relevant files and outline a plan before editing.
+  - Keep diffs minimal and confined to the needed files.
+- **TDD bias**
+  - Add or adjust tests first when behavior changes.
+  - Run `npm test` (none defined yet) or `node cli.mjs --help` as a sanity check.
+- **Commit discipline**
+  - Use `git status` and `git diff` to review.
+  - Commit with concise scope and rationale.
+- **Permissions & safety**
+  - Auto-Accept off by default; confirm before network or file writes.
+  - Avoid modifying generated assets in `vendor/` unless explicitly tasked.
+- **Context hygiene**
+  - Start new tasks with a brief recap of goal and files.
+  - Use checklists or scratch files for multi-step work.
+
+These heuristics help keep interactions deterministic, auditable, and cost‑efficient.


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` capturing lead-user heuristics for working in this repo
- Document explore→plan→code→commit cycle, TDD bias, safety, and context hygiene

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a649a11e648321a1c2682b548eb827

---
## EntelligenceAI PR Summary 
 This PR introduces contributor documentation for development standards.
- Added CLAUDE.md with best practices and workflow guidelines
- No code or functional changes included 

